### PR TITLE
Log a warning for team creation during dry-run operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,5 +78,5 @@ $(MERGED_CONFIG): $(MERGE_CMD) $(CONFIG_FILES)
 		$(shell for o in $(ORGS); do echo "--org-part=$$o=config/$$o/org.yaml"; done) \
 		> $(MERGED_CONFIG)
 
-$(PERIBOLOS_CMD):
-	go build -v -o $(PERIBOLOS_CMD)
+$(PERIBOLOS_CMD): clean
+	go build -v -trimpath -o $(PERIBOLOS_CMD)

--- a/options/root/root.go
+++ b/options/root/root.go
@@ -120,6 +120,7 @@ func (o *Options) validateArgsForAction() error {
 	if o.Config == "" && o.Dump == "" {
 		return fmt.Errorf("--config-path or --dump required")
 	}
+
 	if o.Config != "" && o.Dump != "" {
 		return fmt.Errorf("--config-path=%s and --dump=%s cannot both be set", o.Config, o.Dump)
 	}

--- a/org/dump.go
+++ b/org/dump.go
@@ -127,6 +127,7 @@ func Dump(client dumpClient, orgName string, ignoreSecretTeams bool, appID strin
 		if err != nil {
 			return nil, fmt.Errorf("failed to list team %d(%s) members: %w", t.ID, t.Name, err)
 		}
+
 		logger.Debugf("Found %d members.", len(teamMembers))
 		for _, m := range teamMembers {
 			logger.WithField("login", m.Login).Debug("Recording member.")

--- a/org/org.go
+++ b/org/org.go
@@ -75,7 +75,7 @@ func Configure(opt root.Options, client github.Client, orgName string, orgConfig
 			logrus.Infof("Skipping team repo permissions configuration")
 			continue
 		}
-		if err := configureTeamRepos(client, githubTeams, name, orgName, team); err != nil {
+		if err := configureTeamRepos(opt, client, githubTeams, name, orgName, team); err != nil {
 			return fmt.Errorf("failed to configure %s team %s repos: %w", orgName, name, err)
 		}
 	}

--- a/org/org_test.go
+++ b/org/org_test.go
@@ -1200,7 +1200,10 @@ func TestConfigureTeamMembers(t *testing.T) {
 				newAdmins:  sets.String{},
 				newMembers: sets.String{},
 			}
-			err := configureTeamMembers(fc, "", gt, tc.team, false)
+
+			opts := root.Options{}
+
+			err := configureTeamMembers(opts, fc, "", gt, tc.team, false)
 			switch {
 			case err != nil:
 				if !tc.err {
@@ -2366,7 +2369,10 @@ func TestConfigureTeamRepos(t *testing.T) {
 			failUpdate: testCase.failUpdate,
 			failRemove: testCase.failRemove,
 		}
-		err := configureTeamRepos(&client, testCase.githubTeams, testCase.teamName, "org", testCase.team)
+
+		opts := root.Options{}
+
+		err := configureTeamRepos(opts, &client, testCase.githubTeams, testCase.teamName, "org", testCase.team)
 		if err == nil && testCase.expectedErr {
 			t.Errorf("%s: expected an error but got none", testCase.name)
 		}

--- a/org/teams.go
+++ b/org/teams.go
@@ -295,7 +295,7 @@ func configureTeamMembers(opt root.Options, client teamMembersClient, orgName st
 
 	members, err := client.ListTeamMembersBySlug(orgName, gt.Slug, github.RoleMember)
 	if err != nil && strings.Contains(err.Error(), "404") && !opt.Confirm {
-		logrus.Warnf("Runnning dry-run, Team %s does not exist yet, cannot retrieve team members, ignoring...", gt.Slug)
+		logrus.Warnf("Running dry-run, Team %s does not exist yet, cannot retrieve team members, ignoring...", gt.Slug)
 	} else if err != nil {
 		return fmt.Errorf("failed to list %s(%s) members: %w", gt.Slug, gt.Name, err)
 	}
@@ -305,7 +305,7 @@ func configureTeamMembers(opt root.Options, client teamMembersClient, orgName st
 
 	maintainers, err := client.ListTeamMembersBySlug(orgName, gt.Slug, github.RoleMaintainer)
 	if err != nil && strings.Contains(err.Error(), "404") && !opt.Confirm {
-		logrus.Warnf("Runnning dry-run, Team %s does not exist yet, cannot retrieve team maintainers, ignoring...", gt.Slug)
+		logrus.Warnf("Running dry-run, Team %s does not exist yet, cannot retrieve team maintainers, ignoring...", gt.Slug)
 	} else if err != nil {
 		return fmt.Errorf("failed to list %s(%s) maintainers: %w", gt.Slug, gt.Name, err)
 	}
@@ -317,7 +317,7 @@ func configureTeamMembers(opt root.Options, client teamMembersClient, orgName st
 	if !ignoreInvitees {
 		invitees, err = teamInvitations(client, orgName, gt.Slug)
 		if err != nil && strings.Contains(err.Error(), "404") && !opt.Confirm {
-			logrus.Warnf("Runnning dry-run, Team %s does not exist yet, cannot retrieve invitations, ignoring...", gt.Slug)
+			logrus.Warnf("Running dry-run, Team %s does not exist yet, cannot retrieve invitations, ignoring...", gt.Slug)
 		} else if err != nil {
 			return fmt.Errorf("failed to list %s(%s) invitees: %w", gt.Slug, gt.Name, err)
 		}
@@ -394,7 +394,7 @@ func configureTeamRepos(opt root.Options, client teamRepoClient, githubTeams map
 	have := map[string]github.RepoPermissionLevel{}
 	repos, err := client.ListTeamReposBySlug(orgName, gt.Slug)
 	if err != nil && strings.Contains(err.Error(), "404") && !opt.Confirm {
-		logrus.Warnf("Runnning dry-run, Team %s does not exist yet, cannot retrieve team repos, ignoring...", gt.Slug)
+		logrus.Warnf("Running dry-run, Team %s does not exist yet, cannot retrieve team repos, ignoring...", gt.Slug)
 	} else if err != nil {
 		return fmt.Errorf("failed to list team %d(%s) repos: %w", gt.ID, name, err)
 	}


### PR DESCRIPTION
instead log a warn message

Fixes: #216 

cc @lelia