### PR TITLE
k/org: Add `restrictions` tool and force strict YAML unmarshalling

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,8 +25,8 @@ import (
 	"github.com/spf13/cobra"
 	proworg "github.com/uwu-tools/peribolos/third_party/k8s.io/test-infra/prow/config/org"
 	"sigs.k8s.io/release-utils/version"
-	"sigs.k8s.io/yaml"
 
+	"github.com/uwu-tools/peribolos/internal/yaml"
 	"github.com/uwu-tools/peribolos/options/merge"
 	"github.com/uwu-tools/peribolos/options/root"
 	"github.com/uwu-tools/peribolos/org"
@@ -128,7 +128,7 @@ func rootCmd(o *root.Options) error {
 			logrus.WithError(err).Fatal("Could not read --config-path file")
 		}
 
-		if err := yaml.UnmarshalStrict(raw, &cfg); err != nil {
+		if err := yaml.Unmarshal(raw, &cfg); err != nil {
 			logrus.WithError(err).Fatal("Failed to load configuration")
 		}
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -128,7 +128,7 @@ func rootCmd(o *root.Options) error {
 			logrus.WithError(err).Fatal("Could not read --config-path file")
 		}
 
-		if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		if err := yaml.UnmarshalStrict(raw, &cfg); err != nil {
 			logrus.WithError(err).Fatal("Failed to load configuration")
 		}
 	}

--- a/cmd/restrictions/main.go
+++ b/cmd/restrictions/main.go
@@ -111,7 +111,7 @@ func unmarshalPathToRestrictionsConfig(path string) (*Config, error) {
 		return nil, fmt.Errorf("read restrictions config: %v", err)
 	}
 	var restrictionsCfg Config
-	if err := yaml.Unmarshal(buf, &restrictionsCfg); err != nil {
+	if err := yaml.UnmarshalStrict(buf, &restrictionsCfg); err != nil {
 		return nil, fmt.Errorf("unmarshal restrictions config: %v", err)
 	}
 	return &restrictionsCfg, nil

--- a/cmd/restrictions/main.go
+++ b/cmd/restrictions/main.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/bmatcuk/doublestar"
+	"github.com/ghodss/yaml"
+	"github.com/sirupsen/logrus"
+
+	"github.com/uwu-tools/peribolos/internal/helpers"
+)
+
+var (
+	emptyRegexp        = regexp.MustCompile("")
+	defaultRestriction = Restriction{Path: "*", AllowedReposRe: []*regexp.Regexp{emptyRegexp}}
+)
+
+var errRestrictionViolation = errors.New("restriction violated")
+
+type Config struct {
+	Restrictions []Restriction `json:"restrictions"`
+}
+
+type Restriction struct {
+	Path           string   `json:"path"`
+	AllowedRepos   []string `json:"allowedRepos,omitempty"`
+	AllowedReposRe []*regexp.Regexp
+}
+
+type options struct {
+	orgs         helpers.FlagMap
+	restrictions string
+}
+
+func main() {
+	o := options{orgs: helpers.FlagMap{}}
+	flag.Var(o.orgs, "orgs", "Each instance adds an org-name=org.yaml part")
+	flag.StringVar(&o.restrictions, "restrictions", "restrictions.yaml", "path to a configuration file containing restrictions")
+	flag.Parse()
+
+	for _, a := range flag.Args() {
+		o.orgs.Set(a)
+	}
+
+	cfg, err := unmarshalPathToRestrictionsConfig(o.restrictions)
+	if err != nil {
+		logrus.Fatalf("Failed to unmarshal restrictions config: %v", err)
+	}
+
+	restrictions, err := compileRegexps(cfg.Restrictions)
+	if err != nil {
+		logrus.Fatalf("Failed to compile regexp for restrictions config: %v", err)
+	}
+
+	var restrictionViolated bool
+	for name, path := range o.orgs {
+		logrus.Infof("Validating restrictions for %s org", name)
+		prefix := filepath.Dir(path)
+		err := filepath.Walk(prefix, func(path string, info os.FileInfo, err error) error {
+			switch {
+			case path == prefix:
+				return nil // Skip base dir
+			case info.IsDir() && filepath.Dir(path) != prefix:
+				logrus.Infof("Skipping %s and its children", path)
+				return filepath.SkipDir // Skip prefix/foo/bar/ dirs
+			case !info.IsDir() && filepath.Dir(path) == prefix && filepath.Base(path) != "org.yaml":
+				return nil // Ignore prefix/foo files
+			case filepath.Base(path) == "teams.yaml" || filepath.Base(path) == "org.yaml":
+				if err := resolveRestriction(restrictions, path); err != nil {
+					if errors.Is(err, errRestrictionViolation) {
+						restrictionViolated = true
+					}
+					logrus.Error(err)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			logrus.Fatalf("Failed to walk through files at %s", path)
+		}
+	}
+	if restrictionViolated {
+		logrus.Fatal("restriction violation(s) detected.")
+	}
+}
+
+func unmarshalPathToRestrictionsConfig(path string) (*Config, error) {
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read restrictions config: %v", err)
+	}
+	var restrictionsCfg Config
+	if err := yaml.Unmarshal(buf, &restrictionsCfg); err != nil {
+		return nil, fmt.Errorf("unmarshal restrictions config: %v", err)
+	}
+	return &restrictionsCfg, nil
+}
+
+func compileRegexps(restrictions []Restriction) ([]Restriction, error) {
+	ret := make([]Restriction, 0, len(restrictions))
+	for _, r := range restrictions {
+		r.AllowedReposRe = make([]*regexp.Regexp, 0, len(r.AllowedRepos))
+		for _, repo := range r.AllowedRepos {
+			re, err := regexp.Compile(repo)
+			if err != nil {
+				return restrictions, fmt.Errorf("failed to parse repo pattern %q: %v", repo, err)
+			}
+			r.AllowedReposRe = append(r.AllowedReposRe, re)
+		}
+		ret = append(ret, r)
+	}
+	return ret, nil
+}
+
+func resolveRestriction(restrictions []Restriction, path string) error {
+	orgCfg, err := helpers.UnmarshalPathToOrgConfig(path)
+	if err != nil {
+		return fmt.Errorf("error in unmarshalling path %s: %v", path, err)
+	}
+	r := getRestrictionForPath(restrictions, path)
+
+	var err2 error
+	for teamName, team := range orgCfg.Teams {
+		for repo := range team.Repos {
+			if !matchesRegexList(repo, r.AllowedReposRe) {
+				err2 = errRestrictionViolation
+				err2 = fmt.Errorf("%w\n%q: cannot define repo %q for team %q", err2, path, repo, teamName)
+			}
+		}
+	}
+	return err2
+}
+
+func getRestrictionForPath(restrictions []Restriction, path string) Restriction {
+	for _, r := range restrictions {
+		if match, err := doublestar.Match(r.Path, path); err == nil && match {
+			return r
+		}
+	}
+	return defaultRestriction
+}
+
+func matchesRegexList(s string, list []*regexp.Regexp) bool {
+	for _, r := range list {
+		if r.MatchString(s) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/restrictions/main.go
+++ b/cmd/restrictions/main.go
@@ -25,8 +25,8 @@ import (
 	"regexp"
 
 	"github.com/bmatcuk/doublestar/v4"
-	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
 
 	"github.com/uwu-tools/peribolos/internal/helpers"
 )

--- a/cmd/restrictions/main.go
+++ b/cmd/restrictions/main.go
@@ -24,7 +24,7 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/bmatcuk/doublestar"
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
 

--- a/cmd/restrictions/main.go
+++ b/cmd/restrictions/main.go
@@ -26,9 +26,9 @@ import (
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/sirupsen/logrus"
-	"sigs.k8s.io/yaml"
 
 	"github.com/uwu-tools/peribolos/internal/helpers"
+	"github.com/uwu-tools/peribolos/internal/yaml"
 )
 
 var (
@@ -111,7 +111,7 @@ func unmarshalPathToRestrictionsConfig(path string) (*Config, error) {
 		return nil, fmt.Errorf("read restrictions config: %v", err)
 	}
 	var restrictionsCfg Config
-	if err := yaml.UnmarshalStrict(buf, &restrictionsCfg); err != nil {
+	if err := yaml.Unmarshal(buf, &restrictionsCfg); err != nil {
 		return nil, fmt.Errorf("unmarshal restrictions config: %v", err)
 	}
 	return &restrictionsCfg, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,7 +26,8 @@ import (
 	"github.com/uwu-tools/peribolos/third_party/k8s.io/test-infra/prow/config/org"
 	"github.com/uwu-tools/peribolos/third_party/k8s.io/test-infra/prow/github"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"sigs.k8s.io/yaml"
+
+	"github.com/uwu-tools/peribolos/internal/yaml"
 )
 
 // TODO(config): Fix tests
@@ -49,7 +50,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	if err := yaml.UnmarshalStrict(raw, &cfg); err != nil {
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
 		fmt.Printf("cannot unmarshal generated config.yaml from %s: %v\n", *configPath, err)
 		os.Exit(1)
 	}
@@ -68,7 +69,7 @@ func readInto(path string, i interface{}) error {
 	if err != nil {
 		return fmt.Errorf("read: %v", err)
 	}
-	if err := yaml.UnmarshalStrict(buf, i); err != nil {
+	if err := yaml.Unmarshal(buf, i); err != nil {
 		return fmt.Errorf("unmarshal: %v", err)
 	}
 	return nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+	if err := yaml.UnmarshalStrict(raw, &cfg); err != nil {
 		fmt.Printf("cannot unmarshal generated config.yaml from %s: %v\n", *configPath, err)
 		os.Exit(1)
 	}
@@ -68,7 +68,7 @@ func readInto(path string, i interface{}) error {
 	if err != nil {
 		return fmt.Errorf("read: %v", err)
 	}
-	if err := yaml.Unmarshal(buf, i); err != nil {
+	if err := yaml.UnmarshalStrict(buf, i); err != nil {
 		return fmt.Errorf("unmarshal: %v", err)
 	}
 	return nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,10 +23,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/uwu-tools/peribolos/third_party/k8s.io/test-infra/prow/config/org"
 	"github.com/uwu-tools/peribolos/third_party/k8s.io/test-infra/prow/github"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/yaml"
 )
 
 // TODO(config): Fix tests

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.6.0
 	github.com/caarlos0/env/v7 v7.1.0
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
-	github.com/ghodss/yaml v1.0.0
 	github.com/gomodule/redigo v1.8.9
 	github.com/google/go-cmp v0.5.9
 	github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ replace github.com/gregjones/httpcache => github.com/alvaroaleman/httpcache v0.0
 
 require (
 	github.com/airconduct/go-probot v0.0.4
+	github.com/bmatcuk/doublestar v1.3.4
 	github.com/caarlos0/env/v7 v7.1.0
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/ghodss/yaml v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace github.com/gregjones/httpcache => github.com/alvaroaleman/httpcache v0.0
 
 require (
 	github.com/airconduct/go-probot v0.0.4
-	github.com/bmatcuk/doublestar v1.3.4
+	github.com/bmatcuk/doublestar/v4 v4.6.0
 	github.com/caarlos0/env/v7 v7.1.0
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,6 @@ github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRr
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
-github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZx
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
-github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
+github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=
+github.com/bmatcuk/doublestar/v4 v4.6.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
 github.com/bradleyfalzon/ghinstallation/v2 v2.6.0 h1:IRY7Xy588KylkoycsUhFpW7cdGpy5Y5BPsz4IfuJtGk=
 github.com/bradleyfalzon/ghinstallation/v2 v2.6.0/go.mod h1:oQ3etOwN3TRH4EwgW5/7MxSVMGlMlzG/O8TU7eYdoSk=

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZx
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
+github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
 github.com/bradleyfalzon/ghinstallation/v2 v2.6.0 h1:IRY7Xy588KylkoycsUhFpW7cdGpy5Y5BPsz4IfuJtGk=
 github.com/bradleyfalzon/ghinstallation/v2 v2.6.0/go.mod h1:oQ3etOwN3TRH4EwgW5/7MxSVMGlMlzG/O8TU7eYdoSk=

--- a/internal/helpers/helper.go
+++ b/internal/helpers/helper.go
@@ -21,9 +21,9 @@ import (
 	"os"
 	"strings"
 
-	"sigs.k8s.io/yaml"
-
 	"github.com/uwu-tools/peribolos/third_party/k8s.io/test-infra/prow/config/org"
+
+	"github.com/uwu-tools/peribolos/internal/yaml"
 )
 
 func ParseKeyValue(s string) (string, string) {
@@ -63,7 +63,7 @@ func UnmarshalPathToOrgConfig(path string) (*org.Config, error) {
 		return nil, fmt.Errorf("read: %v", err)
 	}
 	var cfg org.Config
-	if err := yaml.UnmarshalStrict(buf, &cfg); err != nil {
+	if err := yaml.Unmarshal(buf, &cfg); err != nil {
 		return nil, fmt.Errorf("unmarshal: %v", err)
 	}
 	return &cfg, nil

--- a/internal/helpers/helper.go
+++ b/internal/helpers/helper.go
@@ -57,6 +57,10 @@ func (fm FlagMap) Set(s string) error {
 	return nil
 }
 
+func (fm FlagMap) Type() string {
+	return "Type() is not implemented"
+}
+
 func UnmarshalPathToOrgConfig(path string) (*org.Config, error) {
 	buf, err := os.ReadFile(path)
 	if err != nil {

--- a/internal/helpers/helper.go
+++ b/internal/helpers/helper.go
@@ -63,7 +63,7 @@ func UnmarshalPathToOrgConfig(path string) (*org.Config, error) {
 		return nil, fmt.Errorf("read: %v", err)
 	}
 	var cfg org.Config
-	if err := yaml.Unmarshal(buf, &cfg); err != nil {
+	if err := yaml.UnmarshalStrict(buf, &cfg); err != nil {
 		return nil, fmt.Errorf("unmarshal: %v", err)
 	}
 	return &cfg, nil

--- a/internal/helpers/helper.go
+++ b/internal/helpers/helper.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"github.com/uwu-tools/peribolos/third_party/k8s.io/test-infra/prow/config/org"
 )

--- a/internal/helpers/helper.go
+++ b/internal/helpers/helper.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ghodss/yaml"
+
+	"github.com/uwu-tools/peribolos/third_party/k8s.io/test-infra/prow/config/org"
+)
+
+func ParseKeyValue(s string) (string, string) {
+	p := strings.SplitN(s, "=", 2)
+	if len(p) == 1 {
+		return p[0], ""
+	}
+	return p[0], p[1]
+}
+
+type FlagMap map[string]string
+
+func (fm FlagMap) String() string {
+	var parts []string
+	for key, value := range fm {
+		if value == "" {
+			parts = append(parts, key)
+			continue
+		}
+		parts = append(parts, key+"="+value)
+	}
+	return strings.Join(parts, ",")
+}
+
+func (fm FlagMap) Set(s string) error {
+	k, v := ParseKeyValue(s)
+	if _, present := fm[k]; present {
+		return fmt.Errorf("duplicate key: %s", k)
+	}
+	fm[k] = v
+	return nil
+}
+
+func UnmarshalPathToOrgConfig(path string) (*org.Config, error) {
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read: %v", err)
+	}
+	var cfg org.Config
+	if err := yaml.Unmarshal(buf, &cfg); err != nil {
+		return nil, fmt.Errorf("unmarshal: %v", err)
+	}
+	return &cfg, nil
+}

--- a/internal/yaml/yaml.go
+++ b/internal/yaml/yaml.go
@@ -1,0 +1,31 @@
+// Copyright 2023 uwu-tools Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package yaml
+
+import "sigs.k8s.io/yaml"
+
+// Marshal marshals the object into JSON then converts JSON to YAML and returns the
+// YAML.
+func Marshal(o interface{}) ([]byte, error) {
+	return yaml.Marshal(o)
+}
+
+// Unmarshal strictly converts YAML to JSON then uses JSON to unmarshal
+// into an object, optionally configuring the behavior of the JSON unmarshal.
+func Unmarshal(y []byte, o interface{}, opts ...yaml.JSONOpt) error {
+	return yaml.UnmarshalStrict(y, o, opts...)
+}

--- a/options/merge/flags.go
+++ b/options/merge/flags.go
@@ -17,39 +17,9 @@ limitations under the License.
 package merge
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
-
-type flagMap map[string]string
-
-func (fm flagMap) String() string {
-	var parts []string
-	for key, value := range fm {
-		if value == "" {
-			parts = append(parts, key)
-			continue
-		}
-		parts = append(parts, key+"="+value)
-	}
-	return strings.Join(parts, ",")
-}
-
-func (fm flagMap) Set(s string) error {
-	k, v := parseKeyValue(s)
-	if _, present := fm[k]; present {
-		return fmt.Errorf("duplicate key: %s", k)
-	}
-	fm[k] = v
-	return nil
-}
-
-func (fm flagMap) Type() string {
-	return "Type() is not implemented"
-}
 
 // AddFlags adds this options' flags to the cobra command.
 func (o *Options) AddFlags(cmd *cobra.Command) {
@@ -77,12 +47,4 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 		logrus.Print("Extra", a)
 		_ = o.Orgs.Set(a)
 	}
-}
-
-func parseKeyValue(s string) (string, string) {
-	p := strings.SplitN(s, "=", 2)
-	if len(p) == 1 {
-		return p[0], ""
-	}
-	return p[0], p[1]
 }

--- a/options/merge/merge.go
+++ b/options/merge/merge.go
@@ -24,7 +24,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/uwu-tools/peribolos/third_party/k8s.io/test-infra/prow/config/org"
-	"sigs.k8s.io/yaml"
+
+	"github.com/uwu-tools/peribolos/internal/yaml"
 )
 
 type Options struct {
@@ -89,7 +90,7 @@ func unmarshal(path string) (*org.Config, error) {
 		return nil, fmt.Errorf("read: %v", err)
 	}
 	var cfg org.Config
-	if err := yaml.UnmarshalStrict(buf, &cfg); err != nil {
+	if err := yaml.Unmarshal(buf, &cfg); err != nil {
 		return nil, fmt.Errorf("unmarshal: %v", err)
 	}
 	return &cfg, nil

--- a/options/merge/merge.go
+++ b/options/merge/merge.go
@@ -89,7 +89,7 @@ func unmarshal(path string) (*org.Config, error) {
 		return nil, fmt.Errorf("read: %v", err)
 	}
 	var cfg org.Config
-	if err := yaml.Unmarshal(buf, &cfg); err != nil {
+	if err := yaml.UnmarshalStrict(buf, &cfg); err != nil {
 		return nil, fmt.Errorf("unmarshal: %v", err)
 	}
 	return &cfg, nil

--- a/options/merge/merge.go
+++ b/options/merge/merge.go
@@ -25,18 +25,19 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/uwu-tools/peribolos/third_party/k8s.io/test-infra/prow/config/org"
 
+	"github.com/uwu-tools/peribolos/internal/helpers"
 	"github.com/uwu-tools/peribolos/internal/yaml"
 )
 
 type Options struct {
-	Orgs        flagMap
+	Orgs        helpers.FlagMap
 	MergeTeams  bool
 	IgnoreTeams bool
 }
 
 func NewOptions() *Options {
 	o := &Options{
-		Orgs: flagMap{},
+		Orgs: helpers.FlagMap{},
 	}
 
 	return o

--- a/options/merge/merge.go
+++ b/options/merge/merge.go
@@ -22,9 +22,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
 	"github.com/uwu-tools/peribolos/third_party/k8s.io/test-infra/prow/config/org"
+	"sigs.k8s.io/yaml"
 )
 
 type Options struct {


### PR DESCRIPTION
Part of https://github.com/uwu-tools/peribolos/issues/169.
Carries elements of the following PRs: https://github.com/kubernetes/org/pull/2614, https://github.com/kubernetes/org/pull/4421

- cmd: Add `restrictions` from kubernetes/org
- go.mod: Update bmatcuk/doublestar to v4.6.0
- go.mod: Replace ghodss/yaml with sigs.k8s.io/yaml
- Use strict unmarshalling for YAML configs
- internal: Add `yaml` package
- options/merge: Dedupe `FlagMap` logic

Signed-off-by: Stephen Augustus <foo@auggie.dev>