### PR TITLE
Harden GitHub Actions workflows and improve security policy

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,6 +47,8 @@ jobs:
 
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,33 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high
+          deny-licenses: AGPL-1.0, AGPL-3.0
+          comment-summary-in-pr: always
+          warn-on-openssf-scorecard-level: 3

--- a/.github/workflows/postsubmits.yml
+++ b/.github/workflows/postsubmits.yml
@@ -18,6 +18,8 @@ jobs:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: set token
         run: echo ${{ secrets.AUGGIE_BOT_TOKEN }} > token
       - name: peribolos dry-run

--- a/.github/workflows/presubmits.yml
+++ b/.github/workflows/presubmits.yml
@@ -21,6 +21,8 @@ jobs:
         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -40,6 +42,8 @@ jobs:
         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -64,6 +68,8 @@ jobs:
         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
     tags:
       - v*
 
+permissions: read-all
+
 env:
   COSIGN_EXPERIMENTAL: true
 
@@ -26,12 +28,15 @@ jobs:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.25'
           check-latest: true
+          cache: false
 
       - name: Install ko
         uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,32 @@
+name: GitHub Actions Security Analysis
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "**"
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,52 @@
-# Reporting Security Issues
+# Security Policies and Procedures
 
-To report a security issue, please email
-[uwu-tools-team](mailto:uwu-tools-team@googlegroups.com)
-with a description of the issue, the steps you took to create the issue,
-affected versions, and, if known, mitigations for the issue.
+The peribolos maintainers take all security issues seriously.
+Thank you for improving the security of peribolos.
+We appreciate your efforts and responsible disclosure
+and will make every effort to acknowledge your contributions.
+
+## Reporting a Vulnerability
+
+Report security vulnerabilities using
+[GitHub's private vulnerability reporting](https://github.com/uwu-tools/peribolos/security/advisories/new).
+
+Please include the following details in your report:
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- Affected versions
+- Any known mitigations
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+## Vulnerability Management Process
+
+When a vulnerability is reported, the maintainers will:
+
+1. **Acknowledge** the report within three (3) business days.
+2. **Investigate** the issue, confirm the vulnerability,
+   and determine affected versions.
+3. **Provide a detailed response** within an additional three (3) business days,
+   including an assessment and planned timeline for a fix.
+4. **Audit** the codebase for similar issues.
+5. **Prepare fixes** for all maintained releases and coordinate disclosure.
+
+## Disclosure Policy
+
+We follow a coordinated disclosure process:
+
+- Reporters will be kept informed of progress throughout the process.
+- Fixes will be prepared and tested before any public disclosure.
+- Credit will be given to reporters in release notes
+  (unless anonymity is requested).
+
+## Escalation
+
+If you do not receive a timely response via GitHub,
+or if you are unable to use the private vulnerability reporting feature,
+please contact the [uwu-tools team](mailto:uwu-tools-team@googlegroups.com).
+
+## Suggestions for Improvement
+
+If you have suggestions for how this security process could be improved,
+please submit a pull request or open an issue.


### PR DESCRIPTION
## Summary

Addresses the OpenSSF Scorecard violations reported in #546 by hardening GitHub Actions workflows and improving the security policy.

- **Add dependency review workflow** — blocks high-severity vulnerabilities and AGPL-licensed dependencies on PRs, warns on low OpenSSF Scorecard scores
- **Add zizmor workflow** — integrates [zizmor](https://docs.zizmor.sh) GitHub Actions security analysis with Advanced Security/SARIF upload
- **Fix artipacked findings** — set `persist-credentials: false` on all `actions/checkout` steps to prevent credential persistence through artifacts
- **Fix cache-poisoning** — disable `setup-go` cache on the release/publishing workflow to prevent cache poisoning attacks
- **Add top-level `permissions: read-all`** to `release.yml` for least-privilege token scoping
- **Expand `SECURITY.md`** with disclosure process, vulnerability management procedures, response timelines, and escalation contact (addresses Scorecard's Security-Policy finding)

## Remaining items (require repo admin action)

- **Branch protection settings** — enable codeowners review, last push approval, stale review dismissal, up-to-date branches, and enforce for admins
- **GitHub Environments** — create environments for `postsubmits` and `scorecard` jobs to resolve `secrets-outside-env` zizmor warnings
- **CII Best Practices badge** — complete the [OpenSSF Best Practices questionnaire](https://www.bestpractices.dev/)
- **Fuzzing** — consider OSS-Fuzz integration or Go fuzz tests

Resolves #546

## Test plan

- [ ] Verify dependency review workflow triggers on PRs and blocks high-severity deps
- [ ] Verify zizmor workflow runs and uploads SARIF to Advanced Security dashboard
- [ ] Verify existing workflows (CodeQL, presubmits, postsubmits, release, scorecard) still function correctly with `persist-credentials: false`
- [ ] Confirm release workflow works with `cache: false` on `setup-go`
- [ ] Check OpenSSF Scorecard re-run shows improved score

🤖 Generated with [Claude Code](https://claude.com/claude-code)