### PR TITLE
Bump stale codeql-action pins and add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  cooldown:
+    default-days: 7
   groups:
     gomod:
       patterns:
@@ -17,6 +19,8 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  cooldown:
+    default-days: 7
   groups:
     github-actions:
       patterns:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,7 +52,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@421a1b344fb0def373a0794a4051f19f207461ec # v2.2.1
+      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -63,7 +63,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@421a1b344fb0def373a0794a4051f19f207461ec # v2.2.1
+      uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -77,4 +77,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@421a1b344fb0def373a0794a4051f19f207461ec # v2.2.1
+      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -68,6 +68,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@421a1b344fb0def373a0794a4051f19f207461ec # v2.2.1
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- **Bump `github/codeql-action` from `codeql-bundle-20230120` to v4.35.1** — the pinned SHA corresponded to `codeql-bundle-20230120` but was incorrectly commented as `v2.2.1`, triggering `zizmor/ref-version-mismatch` alerts across `codeql-analysis.yml` (init, autobuild, analyze) and `scorecard.yml` (upload-sarif). Updated to the current v4.35.1 release with the correct dereferenced commit SHA.
- **Add `cooldown: default-days: 7`** to both dependabot ecosystem entries — mitigates supply chain risk by waiting 7 days before pulling in newly published packages, giving the ecosystem time to detect and yank compromised releases

## Remaining open alerts (require admin/external action)

| Type | Action needed |
|---|---|
| Branch-Protection | Enable codeowners review, last push approval, up-to-date branches in repo settings |
| Maintained | Needs more issue activity (will improve naturally) |
| Fuzzing | OSS-Fuzz or Go fuzz tests (separate initiative) |
| CII-Best-Practices | Complete [OpenSSF Best Practices](https://www.bestpractices.dev/) questionnaire |
| Token-Permissions (top-level) | Already fixed in #574, awaiting Scorecard re-scan |
| Token-Permissions (packages:write) | Expected — release job needs this for GHCR |
| Security-Policy | Already fixed in #574, awaiting Scorecard re-scan |

## Test plan

- [ ] Verify CodeQL workflow runs successfully with v4.35.1 actions
- [ ] Verify Scorecard workflow uploads SARIF with updated `upload-sarif` action
- [ ] Confirm zizmor no longer reports `ref-version-mismatch` or `dependabot-cooldown` findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)